### PR TITLE
Use global path variable

### DIFF
--- a/AI/source/Global.hpp
+++ b/AI/source/Global.hpp
@@ -4,3 +4,4 @@
 
 #define GLOBAL_SLEEP(x) std::this_thread::sleep_for(std::chrono::milliseconds(x));
 #define GLOBAL_SIGN(x) ((x > 0) - (x < 0))
+const std::string DOLPHIN_PATH = "/home/tom/.dolphin-emu";

--- a/AI/source/MemReader.cpp
+++ b/AI/source/MemReader.cpp
@@ -1,8 +1,9 @@
+#include "Global.hpp"
 #include "MemReader.hpp"
 
 #include <iostream>
 
-#define PATH "/home/tom/.dolphin-emu/MemoryWatcher/MemoryWatcher"
+std::string MemReader::memPath = DOLPHIN_PATH + "/MemoryWatcher/MemoryWatcher";
 
 std::thread MemReader::Init() {
   //TODO: can only call this once
@@ -19,8 +20,8 @@ void MemReader::SocketSetup() {
   fd = socket(AF_UNIX, SOCK_DGRAM, 0); //TODO: add error handling
   memset(&addr, 0, sizeof(addr));
   addr.sun_family = AF_UNIX;
-  unlink(PATH);
-  strncpy(addr.sun_path, PATH, sizeof(addr.sun_path) - 1);
+  unlink(memPath.c_str());
+  strncpy(addr.sun_path, memPath.c_str(), sizeof(addr.sun_path) - 1);
   bind(fd, (struct sockaddr*) &addr, sizeof(addr));//TODO: add error handling
 }
 

--- a/AI/source/MemReader.hpp
+++ b/AI/source/MemReader.hpp
@@ -42,6 +42,7 @@ class MemReader {
 
 private:
 
+  static std::string memPath;
   std::map<std::string,int> m_address_index { 
     {"8045310E", p1_stocks},
     {"80453F9E", p2_stocks},

--- a/AI/source/PipeController.cpp
+++ b/AI/source/PipeController.cpp
@@ -1,9 +1,10 @@
+#include "Global.hpp"
 #include "PipeController.hpp"
 
 #include <cmath>
 
 
-std::string PipeController::pipePath = "/home/tom/.dolphin-emu/Pipes/pipe";
+std::string PipeController::pipePath = DOLPHIN_PATH + "/Pipes/pipe";
 
 PipeController::PipeController() {
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Inside the dolphin home folder you must create a FIFO pipe named ```pipe```, a `
 This is done with the following commands:
 
 ```bash
-$ cd dolphin-emu
+$ cd /path/to/dolphin-emu
 $ mkdir Pipes
 $ mkfifo Pipes/pipe
 $ mkdir MemoryWatcher
@@ -30,13 +30,11 @@ An example of addresses that can be used to populate ```Locations.txt``` is give
 Next you must tweak and build the source code.
 Navigate to the source directory at ```MeleeAI/AI/source```.
 There is a string (path) variable that needs to be changed to match the specifics of your system.
-In ```Global.hpp```, modify
+In ```Global.hpp```, modify the ```DOLPHIN_PATH``` variable to match the path of your dolphin home folder:
 
 ```C++
-const std::string DOLPHIN_PATH = "/home/tom/.dolphin-emu";
+const std::string DOLPHIN_PATH = "/path/to/dolphin-emu";
 ```
-
-to match the path of your dophin home folder.
 
 Navigate to the parent directory of the source folder, ```MeleeAI/AI```, and make and run MeleeAI with
 

--- a/README.md
+++ b/README.md
@@ -28,23 +28,15 @@ $ touch MemoryWatcher/Locations.txt
 An example of addresses that can be used to populate ```Locations.txt``` is given at the top of ```MeleeAI/MeleeNotes.txt```.
 
 Next you must tweak and build the source code.
-Navigate to the source directory at ```MeleeAI/AI/source```
-There are two string (path) variables that need to be changed to match the specifics of your system.
-One is in ```MemReader.cpp```: modify
+Navigate to the source directory at ```MeleeAI/AI/source```.
+There is a string (path) variable that needs to be changed to match the specifics of your system.
+In ```Global.hpp```, modify
 
 ```C++
-#define PATH "/home/tom/.dolphin-emu/MemoryWatcher/MemoryWatcher"
+const std::string DOLPHIN_PATH = "/home/tom/.dolphin-emu";
 ```
 
-with respect to the path of your ```MemoryWatcher/``` directory.
-```MemoryWatcher/Memorywatcher``` is a socket that is used to watch the addresses listed in ```Locations.txt```.
-Next, in ```PipeController.cpp```, modify
-
-```C++
-std::string PipeController::pipePath = "/home/tom/.dolphin-emu/Pipes/pipe";
-```
-
-with respect to the path of your ```Pipes/pipe``` file.
+to match the path of your dophin home folder.
 
 Navigate to the parent directory of the source folder, ```MeleeAI/AI```, and make and run MeleeAI with
 


### PR DESCRIPTION
I created a global variable, ```DOLPHIN_PATH```, that contains the path of the dolphin home folder.  This makes MeleeAI a bit easier to configure, since the user only has to change one path variable instead of two.

I also updated the README instructions to reflect this change.