### PR TITLE
Accept /path/to/dolphin-emu as a command line argument

### DIFF
--- a/AI/source/AI/AI.cpp
+++ b/AI/source/AI/AI.cpp
@@ -6,9 +6,9 @@
 #include <cmath>
 #include <iostream>
 
-AI::AI() {
+AI::AI(Controller* controller) {
     m_game_state = GameState::Instance();
-    m_move_set = new MoveSet();
+    m_move_set = new MoveSet(controller);
     m_generator = new std::default_random_engine;
 }
 

--- a/AI/source/AI/AI.hpp
+++ b/AI/source/AI/AI.hpp
@@ -25,7 +25,7 @@ public:
     double Ycoord();
     double Uniform(double,double);
 
-    AI();
+    AI(Controller*);
     ~AI();
     
 protected:

--- a/AI/source/AI/DIBot.hpp
+++ b/AI/source/AI/DIBot.hpp
@@ -5,7 +5,7 @@
 
 class DIBot : AI {
 public:
-    DIBot() : AI() {}
+    DIBot(Controller* controller) : AI(controller) {}
     void DI();
 
 private:

--- a/AI/source/AI/DefensiveAI.cpp
+++ b/AI/source/AI/DefensiveAI.cpp
@@ -3,11 +3,11 @@
 
 #include <iostream>
 
-DefensiveAI::DefensiveAI() : AI() {
-    m_recovery_bot = new RecoveryFox();
-    m_ledge_bot = new LedgeBot();
-    m_di_bot = new DIBot();
-    m_tech_bot = new TechBot();
+DefensiveAI::DefensiveAI(Controller* controller) : AI(controller) {
+    m_recovery_bot = new RecoveryFox(controller);
+    m_ledge_bot = new LedgeBot(controller);
+    m_di_bot = new DIBot(controller);
+    m_tech_bot = new TechBot(controller);
 }
 
 DefensiveAI::~DefensiveAI() {

--- a/AI/source/AI/DefensiveAI.hpp
+++ b/AI/source/AI/DefensiveAI.hpp
@@ -10,7 +10,7 @@
 
 class DefensiveAI : public AI {
 public:
-    DefensiveAI();
+    DefensiveAI(Controller*);
     ~DefensiveAI();
 
     void MakeMove();

--- a/AI/source/AI/LedgeBot.hpp
+++ b/AI/source/AI/LedgeBot.hpp
@@ -5,7 +5,7 @@
 
 class LedgeBot : public AI {
 public:
-    LedgeBot() : AI() {}
+    LedgeBot(Controller* controller) : AI(controller) {}
     virtual ~LedgeBot() {}
 
     void GetUp();

--- a/AI/source/AI/MoveSet.cpp
+++ b/AI/source/AI/MoveSet.cpp
@@ -5,10 +5,10 @@
 
 //TODO: Have moves return the number of frames they waited
 
-MoveSet::MoveSet() {
-    m_controller = new PipeController();
+MoveSet::MoveSet(Controller* controller) {
+    m_controller = controller;
 }
-
+ 
 MoveSet::~MoveSet() {
     delete m_controller;
 }

--- a/AI/source/AI/MoveSet.hpp
+++ b/AI/source/AI/MoveSet.hpp
@@ -5,7 +5,7 @@
 
 class MoveSet {
 public:
-    MoveSet();
+    MoveSet(Controller*);
     ~MoveSet();
 
     void UpB();

--- a/AI/source/AI/RecoveryBot/RecoveryBot.hpp
+++ b/AI/source/AI/RecoveryBot/RecoveryBot.hpp
@@ -9,7 +9,7 @@ private:
 
 public:
 
-  RecoveryBot() : AI() {}
+  RecoveryBot(Controller* controller) : AI(controller) {}
   virtual ~RecoveryBot() {}
   
   virtual void Recover() = 0;

--- a/AI/source/AI/RecoveryBot/RecoveryFox.hpp
+++ b/AI/source/AI/RecoveryBot/RecoveryFox.hpp
@@ -9,7 +9,7 @@ private:
 
 public:
 
-  RecoveryFox() : RecoveryBot() {}
+  RecoveryFox(Controller* controller) : RecoveryBot(controller) {}
  
   void Recover();
 

--- a/AI/source/AI/TechBot.hpp
+++ b/AI/source/AI/TechBot.hpp
@@ -5,7 +5,7 @@
 
 class TechBot : public AI {
 public:
-    TechBot() : AI() {}
+    TechBot(Controller* controller) : AI(controller) {}
     void Tech();
 
 private:

--- a/AI/source/Global.hpp
+++ b/AI/source/Global.hpp
@@ -8,4 +8,3 @@
 #define GLOBAL_SLEEP(x) std::this_thread::sleep_for(std::chrono::milliseconds(x));
 #define GLOBAL_WAIT_FRAMES(x) GameState::WaitFrames(x);
 #define GLOBAL_SIGN(x) ((x > 0) - (x < 0))
-const std::string DOLPHIN_PATH = "/home/tom/.dolphin-emu";

--- a/AI/source/MeleeAI.cpp
+++ b/AI/source/MeleeAI.cpp
@@ -1,6 +1,7 @@
 #include "Global.hpp"
 #include "GameState.hpp"
 #include "MemReader.hpp"
+#include "PipeController.hpp"
 #include "AI/AI.hpp"
 #include "AI/DefensiveAI.hpp"
 
@@ -8,7 +9,8 @@
 
 int main() {
     std::thread mem_reader_thread = MemReader::Init();
-    DefensiveAI* ai = new DefensiveAI();
+    PipeController* controller = new PipeController();
+    DefensiveAI* ai = new DefensiveAI(controller);
     GameState* game_state = GameState::Instance();
     
     while (1) {

--- a/AI/source/MeleeAI.cpp
+++ b/AI/source/MeleeAI.cpp
@@ -5,17 +5,22 @@
 #include "AI/AI.hpp"
 #include "AI/DefensiveAI.hpp"
 
+#include <iostream>
 #include <thread>
 
-int main() {
-    std::thread mem_reader_thread = MemReader::Init();
-    PipeController* controller = new PipeController();
-    DefensiveAI* ai = new DefensiveAI(controller);
-    GameState* game_state = GameState::Instance();
-    
-    while (1) {
-        //TODO: check for pause here as well, need to add mem address for that
-        while (!game_state->in_game) {GLOBAL_WAIT_FRAMES(1)}
-        ai->MakeMove();
+int main(int argc, const char* argv[]) {
+    if (argc != 2) {
+        std::cout << "Usage: " << argv[0] << " /path/to/dolphin-emu\n";
+    } else {
+        std::thread mem_reader_thread = MemReader::Init(argv[1]);
+        PipeController* controller = new PipeController(argv[1]);
+        DefensiveAI* ai = new DefensiveAI(controller);
+        GameState* game_state = GameState::Instance();
+        
+        while (1) {
+            //TODO: check for pause here as well, need to add mem address for that
+            while (!game_state->in_game) {GLOBAL_WAIT_FRAMES(1)}
+            ai->MakeMove();
+        }
     }
 }

--- a/AI/source/MemReader.cpp
+++ b/AI/source/MemReader.cpp
@@ -3,9 +3,10 @@
 
 #include <iostream>
 
-std::string MemReader::memPath = DOLPHIN_PATH + "/MemoryWatcher/MemoryWatcher";
+std::string MemReader::memPath = "";
 
-std::thread MemReader::Init() {
+std::thread MemReader::Init(std::string path) {
+    memPath = path + "/MemoryWatcher/MemoryWatcher";
     //TODO: can only call this once
     MemReader* mr = new MemReader(GameState::Instance());
     return std::thread([=] {mr->MonitorMemory();});

--- a/AI/source/MemReader.hpp
+++ b/AI/source/MemReader.hpp
@@ -40,7 +40,7 @@ enum MemoryAddress
 
 class MemReader {   
 public:
-    static std::thread Init();
+    static std::thread Init(std::string);
     
 private:
     static std::string memPath;

--- a/AI/source/PipeController.cpp
+++ b/AI/source/PipeController.cpp
@@ -3,10 +3,10 @@
 
 #include <cmath>
 
+std::string PipeController::pipePath = "";
 
-std::string PipeController::pipePath = DOLPHIN_PATH + "/Pipes/pipe";
-
-PipeController::PipeController() {
+PipeController::PipeController(std::string path) {
+    pipePath = path + "/Pipes/pipe";
     namedPipe = new std::ofstream();
     namedPipe->open (pipePath);
 }

--- a/AI/source/PipeController.hpp
+++ b/AI/source/PipeController.hpp
@@ -8,7 +8,7 @@
 
 class PipeController : public Controller {
 public:
-    PipeController();
+    PipeController(std::string);
     ~PipeController();
     void Press(char);
     void Release(char);

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Installation
 
 This series of steps will guide you in installing MeleeAI from the terminal.
-MeleeAI is currently functional on Linux and OS X platforms.
+MeleeAI is currently functional on Linux and OS X platforms with [Dolphin](https://dolphin-emu.org) version 4.0-8510 or later.
 
 To begin, download a copy of the MeleeAI repository:
 
@@ -20,6 +20,7 @@ Possible locations of this folder on Linux include the `$HOME` directory or `$HO
 Inside the dolphin home folder you must create a FIFO pipe named `pipe`, a `Locations.txt` that contains a list of line-separated memory addresses that MemoryWatcher will watch, and the folders that contain them, respectively.
 An example `Locations.txt` that MeleeAI is designed to function with is available in the MeleeAI repository.
 This setup can be completed with the following commands:
+
 
 ```bash
 $ cd /path/to/dolphin-emu
@@ -52,40 +53,33 @@ Then click 'Configure' to the right.
 There should be an option to select 'Pipe/0/pipe' (possibly named 'Pipe/1/pipe').
 If there is no such device, go back to [Setup the Dolphin home folder](#setup-the-dolphin-home-folder) and make sure that you have created the `pipe` file in the correct location.
 4. Having selected the device, click the 'Profile' drop-down menu to the right.
-There should be an option to select 'pipe' -- if not, return to the steps above and ensure that `pipe.ini` has been copied to the correct location.
+There should be an option to select 'pipe' — if not, return to the steps above and ensure that `pipe.ini` has been copied to the correct location.
 Select 'pipe' and click 'Load' to the right.
 5. In the bottom right, under 'Options', click the box next to 'Background Input'.
 Then click 'OK' to exit the configure menu and 'OK' again to exit the controllers menu.
 
 ### Build and Run MeleeAI
 
-Finally, you must tweak and build the MeleeAI source code.
-Navigate to the source directory at `MeleeAI/AI/source`.
-There is a string (path) variable that needs to be changed to match the specifics of your system.
-In `Global.hpp`, modify the `DOLPHIN_PATH` variable to match the path of your dolphin home folder:
-
-```C++
-const std::string DOLPHIN_PATH = "/path/to/dolphin-emu";
-```
-(Note: If your path contains a space, [as with the OS X example above](#setup-the-dolphin-home-folder), you will need to escape it with `\\`, e.g., 
-```C++
-const std::string DOLPHIN_PATH = /Users/username/Library/Application\\ Support/Dolphin";
-```
-)
-
-Navigate to the parent directory of the source folder, `MeleeAI/AI`, and make and run MeleeAI with
+Finally, you must build and run MeleeAI.
+Navigate to the `MeleeAI/AI` and run the following commands:
 
 ```bash
 $ mkdir build
 $ make
 ```
 
-Inside Dolphin, load up melee.
-When on the character select screen, run MeleeAI:
+Inside Dolphin, load up Melee.
+When on the character select screen, run MeleeAI and provide it with the path to your dolphin home folder:
 
 ```bash
-$ ./MeleeAI
+$ ./MeleeAI /path/to/dolphin-emu
 ```
+
+(Note: If your path contains a space, [as with the OS X example above](#setup-the-dolphin-home-folder), you will need to escape it before handing it to MeleeAI, e.g.,
+```bash
+$ ./MeleeAI "/Users/username/Library/Application\ Support/Dolphin"
+```
+)
 
 Choose your character, select Fox for Player 2 and select a stage.
 If MeleeAI is working, when Fox is knocked off the stage, he will attempt to recover intelligently.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,11 @@ $ ./MeleeAI /path/to/dolphin-emu
 
 (Note: If your path contains a space, [as with the OS X example above](#setup-the-dolphin-home-folder), you will need to escape it before handing it to MeleeAI, e.g.,
 ```bash
-$ ./MeleeAI "/Users/username/Library/Application\ Support/Dolphin"
+$ ./MeleeAI /Users/username/Library/Application\ Support/Dolphin
+```
+or, particularly if there are several spaces or other ambiguous characters,
+```bash
+$ ./MeleeAI "/Users/username/Library/Application Support/Dolphin"
 ```
 )
 


### PR DESCRIPTION
In discussion with @sepharoth213, and to make this change a bit easier to implement, I went ahead and reworked the code structure a little bit.  Now instead of each child of the `AI` class creating its own controller, a single controller is created, given the `/path/to/dolphin-emu` as an argument, and passed to each child of `AI` that needs it.